### PR TITLE
[feat] GlobalExceptionHandler 예외 핸들러 추가

### DIFF
--- a/src/main/java/_ganzi/codoc/global/api/GlobalExceptionHandler.java
+++ b/src/main/java/_ganzi/codoc/global/api/GlobalExceptionHandler.java
@@ -71,12 +71,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception exception) {
-        log.error("서버 에러 발생", exception);
-        return ResponseEntity.status(GlobalErrorCode.INTERNAL_SERVER_ERROR.status())
-                .body(
-                        ApiResponse.error(
-                                GlobalErrorCode.INTERNAL_SERVER_ERROR.code(),
-                                GlobalErrorCode.INTERNAL_SERVER_ERROR.message()));
+        GlobalErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        log.error("[{}] {}", errorCode.code(), errorCode.message(), exception);
+        return ResponseEntity.status(errorCode.status())
+                .body(ApiResponse.error(errorCode.code(), errorCode.message()));
     }
 
     private Map<String, String> toFieldErrors(Iterable<FieldError> fieldErrors) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #52 

## 📝 작업 내용
- GlobalExceptionHandler에 입력값 검증 예외 핸들러를 추가했습니다.
- 로그에 하드코딩되어 있던 것을 수정했습니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
 - `MethodArgumentNotValidException`: `@RequestBody` + `@Valid/@Validated` 사용 시 JSON 바디를 객체로 역직렬화한 뒤 Bean Validation이 실패하면 발생. 주로 REST 요청 바디 검증 실패.

  - `BindException`: `@ModelAttribute`/폼 데이터/쿼리스트링 바인딩 대상 객체에 대한 검증이 실패했을 때 발생. 즉 요청 바디가 아닌 데이터 바인딩 + 검증 실패.

  - `ConstraintViolationException`: `@RequestParam`, `@PathVariable`, 메서드 파라미터/리턴값 등 “값 자체”에 붙은 제약조건이 `@Validated`로 검사될 때 실패하면 발생. 메서드 레벨 검증 실패 케이스.

