### PR TITLE
[refactor] 문제 도메인 domain 패키지 분리

### DIFF
--- a/src/main/java/_ganzi/codoc/problem/domain/Problem.java
+++ b/src/main/java/_ganzi/codoc/problem/domain/Problem.java
@@ -1,6 +1,7 @@
 package _ganzi.codoc.problem.domain;
 
 import _ganzi.codoc.global.domain.BaseTimeEntity;
+import _ganzi.codoc.problem.enums.ProblemLevel;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/_ganzi/codoc/problem/domain/UserProblemResult.java
+++ b/src/main/java/_ganzi/codoc/problem/domain/UserProblemResult.java
@@ -1,6 +1,7 @@
 package _ganzi.codoc.problem.domain;
 
 import _ganzi.codoc.global.domain.BaseTimeEntity;
+import _ganzi.codoc.problem.enums.ProblemSolvingStatus;
 import _ganzi.codoc.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/_ganzi/codoc/problem/dto/ProblemListCondition.java
+++ b/src/main/java/_ganzi/codoc/problem/dto/ProblemListCondition.java
@@ -1,7 +1,7 @@
 package _ganzi.codoc.problem.dto;
 
-import _ganzi.codoc.problem.domain.ProblemLevel;
-import _ganzi.codoc.problem.domain.ProblemSolvingStatus;
+import _ganzi.codoc.problem.enums.ProblemLevel;
+import _ganzi.codoc.problem.enums.ProblemSolvingStatus;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;

--- a/src/main/java/_ganzi/codoc/problem/dto/ProblemListItem.java
+++ b/src/main/java/_ganzi/codoc/problem/dto/ProblemListItem.java
@@ -1,7 +1,7 @@
 package _ganzi.codoc.problem.dto;
 
-import _ganzi.codoc.problem.domain.ProblemLevel;
-import _ganzi.codoc.problem.domain.ProblemSolvingStatus;
+import _ganzi.codoc.problem.enums.ProblemLevel;
+import _ganzi.codoc.problem.enums.ProblemSolvingStatus;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/_ganzi/codoc/problem/enums/ProblemLevel.java
+++ b/src/main/java/_ganzi/codoc/problem/enums/ProblemLevel.java
@@ -1,4 +1,4 @@
-package _ganzi.codoc.problem.domain;
+package _ganzi.codoc.problem.enums;
 
 public enum ProblemLevel {
     ONE,

--- a/src/main/java/_ganzi/codoc/problem/enums/ProblemSolvingStatus.java
+++ b/src/main/java/_ganzi/codoc/problem/enums/ProblemSolvingStatus.java
@@ -1,4 +1,4 @@
-package _ganzi.codoc.problem.domain;
+package _ganzi.codoc.problem.enums;
 
 public enum ProblemSolvingStatus {
     NOT_ATTEMPTED,

--- a/src/main/java/_ganzi/codoc/problem/repository/ProblemRepository.java
+++ b/src/main/java/_ganzi/codoc/problem/repository/ProblemRepository.java
@@ -1,8 +1,8 @@
 package _ganzi.codoc.problem.repository;
 
 import _ganzi.codoc.problem.domain.Problem;
-import _ganzi.codoc.problem.domain.ProblemLevel;
-import _ganzi.codoc.problem.domain.ProblemSolvingStatus;
+import _ganzi.codoc.problem.enums.ProblemLevel;
+import _ganzi.codoc.problem.enums.ProblemSolvingStatus;
 import _ganzi.codoc.problem.dto.ProblemListItem;
 import java.util.List;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/_ganzi/codoc/problem/service/ProblemService.java
+++ b/src/main/java/_ganzi/codoc/problem/service/ProblemService.java
@@ -1,10 +1,10 @@
 package _ganzi.codoc.problem.service;
 
-import _ganzi.codoc.problem.domain.ProblemLevel;
-import _ganzi.codoc.problem.domain.ProblemSolvingStatus;
 import _ganzi.codoc.problem.dto.ProblemListCondition;
 import _ganzi.codoc.problem.dto.ProblemListItem;
 import _ganzi.codoc.problem.dto.ProblemListResponse;
+import _ganzi.codoc.problem.enums.ProblemLevel;
+import _ganzi.codoc.problem.enums.ProblemSolvingStatus;
 import _ganzi.codoc.problem.repository.ProblemRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #55 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 문제 도메인의 domain 패키지에서 enum과 Repository 클래스를 별도 패키지로 분리했습니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
- 추후 유저 도메인도 동일하게 진행해주시면 될 것 같습니다.