### PR TITLE
[feat] 퀘스트 배치 발급 구현

### DIFF
--- a/src/main/java/_ganzi/codoc/CodocApplication.java
+++ b/src/main/java/_ganzi/codoc/CodocApplication.java
@@ -2,8 +2,10 @@ package _ganzi.codoc;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CodocApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/_ganzi/codoc/user/domain/UserQuest.java
+++ b/src/main/java/_ganzi/codoc/user/domain/UserQuest.java
@@ -4,6 +4,8 @@ import _ganzi.codoc.global.domain.BaseTimeEntity;
 import _ganzi.codoc.user.enums.QuestStatus;
 import jakarta.persistence.*;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +14,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
         name = "user_quest",
-        indexes = {@Index(name = "idx_user_quest_user_status", columnList = "user_id,status")})
+        indexes = {@Index(name = "idx_user_quest_user_status", columnList = "user_id,status")},
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_user_quest_issue",
+                        columnNames = {"user_id", "quest_id", "issued_date"}))
 @Entity
 public class UserQuest extends BaseTimeEntity {
 
@@ -35,15 +41,25 @@ public class UserQuest extends BaseTimeEntity {
     @Column(name = "expires_at", nullable = false)
     private Instant expiresAt;
 
-    private UserQuest(User user, Quest quest, QuestStatus status, Instant expiresAt) {
+    @Column(name = "issued_date", nullable = false)
+    private LocalDate issuedDate;
+
+    private UserQuest(
+            User user, Quest quest, QuestStatus status, Instant expiresAt, LocalDate issuedDate) {
         this.user = user;
         this.quest = quest;
         this.status = status;
         this.expiresAt = expiresAt;
+        this.issuedDate = issuedDate;
     }
 
     public static UserQuest create(User user, Quest quest, Instant expiresAt) {
-        return new UserQuest(user, quest, QuestStatus.IN_PROGRESS, expiresAt);
+        return new UserQuest(
+                user, quest, QuestStatus.IN_PROGRESS, expiresAt, LocalDate.now(ZoneId.of("Asia/Seoul")));
+    }
+
+    public static UserQuest create(User user, Quest quest, Instant expiresAt, LocalDate issuedDate) {
+        return new UserQuest(user, quest, QuestStatus.IN_PROGRESS, expiresAt, issuedDate);
     }
 
     public void markCompleted() {

--- a/src/main/java/_ganzi/codoc/user/service/QuestBatchScheduler.java
+++ b/src/main/java/_ganzi/codoc/user/service/QuestBatchScheduler.java
@@ -1,0 +1,21 @@
+package _ganzi.codoc.user.service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuestBatchScheduler {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    private final QuestBatchService questBatchService;
+
+    @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
+    public void issueDailyQuests() {
+        questBatchService.issueDailyQuests(LocalDate.now(SEOUL));
+    }
+}

--- a/src/main/java/_ganzi/codoc/user/service/QuestBatchService.java
+++ b/src/main/java/_ganzi/codoc/user/service/QuestBatchService.java
@@ -1,0 +1,65 @@
+package _ganzi.codoc.user.service;
+
+import _ganzi.codoc.user.enums.UserStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class QuestBatchService {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    private final EntityManager entityManager;
+
+    @Transactional
+    public void issueDailyQuests(LocalDate issuedDate) {
+        Instant expiresAt = issuedDate.plusDays(1).atStartOfDay(SEOUL).toInstant();
+        String sql =
+                """
+                INSERT INTO user_quest
+                    (user_id, quest_id, status, expires_at, issued_date, created_at, updated_at)
+                SELECT u.id, q.id, 'IN_PROGRESS', :expiresAt, :issuedDate, NOW(6), NOW(6)
+                FROM `user` u
+                CROSS JOIN quest q
+                WHERE u.status = :activeStatus
+                ON DUPLICATE KEY UPDATE updated_at = updated_at
+                """;
+        entityManager
+                .createNativeQuery(sql)
+                .setParameter("expiresAt", expiresAt)
+                .setParameter("issuedDate", issuedDate)
+                .setParameter("activeStatus", UserStatus.ACTIVE.name())
+                .executeUpdate();
+    }
+
+    @Transactional
+    public void issueDailyQuestsForUser(Long userId, LocalDate issuedDate) {
+        Instant expiresAt = issuedDate.plusDays(1).atStartOfDay(SEOUL).toInstant();
+        String sql =
+                """
+                INSERT INTO user_quest
+                    (user_id, quest_id, status, expires_at, issued_date, created_at, updated_at)
+                SELECT :userId, q.id, 'IN_PROGRESS', :expiresAt, :issuedDate, NOW(6), NOW(6)
+                FROM quest q
+                ON DUPLICATE KEY UPDATE updated_at = updated_at
+                """;
+        entityManager
+                .createNativeQuery(sql)
+                .setParameter("userId", userId)
+                .setParameter("expiresAt", expiresAt)
+                .setParameter("issuedDate", issuedDate)
+                .executeUpdate();
+    }
+
+    @Transactional
+    public void issueDailyQuests() {
+        issueDailyQuests(LocalDate.now(SEOUL));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 02:00 마다 모든 Daily 퀘스트를 활성 유저들에게 발급
- onboarding, dormant 유저의 경우 active 전환시 Daily 퀘스트 발급

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
