### PR TITLE
[feat] ChatbotConversation 엔티티 aiMessage 필드 타입 TEXT로 변경

### DIFF
--- a/src/main/java/_ganzi/codoc/chatbot/domain/ChatbotConversation.java
+++ b/src/main/java/_ganzi/codoc/chatbot/domain/ChatbotConversation.java
@@ -24,7 +24,8 @@ public class ChatbotConversation extends BaseTimeEntity {
     @Column(name = "user_message", nullable = false, length = 500)
     private String userMessage;
 
-    @Column(name = "ai_message", length = 500)
+    @Lob
+    @Column(name = "ai_message", columnDefinition = "TEXT")
     private String aiMessage;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 기존 `VARCHAR(500)` 타입은 AI 챗봇의 답변이 긴 경우 오류가 발생해 `TEXT` 타입으로 변경했습니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
