### PR TITLE
feat: access/error/app 로그 역할 분리 및 필터 순서 고정

### DIFF
--- a/src/main/java/_ganzi/codoc/global/config/FilterConfig.java
+++ b/src/main/java/_ganzi/codoc/global/config/FilterConfig.java
@@ -1,0 +1,23 @@
+package _ganzi.codoc.global.config;
+
+import _ganzi.codoc.global.log.LoggingContextFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public LoggingContextFilter loggingContextFilter() {
+        return new LoggingContextFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean<LoggingContextFilter> loggingContextFilterRegistration(
+            LoggingContextFilter filter) {
+        FilterRegistrationBean<LoggingContextFilter> bean = new FilterRegistrationBean<>(filter);
+        bean.setOrder(Integer.MIN_VALUE);
+        return bean;
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,12 +2,26 @@
 
   <property name="LOG_DIR" value="${LOG_DIR:-/home/ubuntu/be/logs}" />
 
+  <!-- 1) 앱(부팅/프레임워크) 로그: 파일로 확실히 남기기 -->
+  <appender name="APP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_DIR}/app.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_DIR}/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>7</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- 2) 콘솔: 개발/긴급 디버깅용(원하면 나중에 제거) -->
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
+  <!-- 3) ACCESS JSON -->
   <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${LOG_DIR}/access.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -19,13 +33,15 @@
       <providers>
         <timestamp><fieldName>timestamp</fieldName></timestamp>
         <logLevel><fieldName>level</fieldName></logLevel>
-        <mdc><fieldName>_mdc</fieldName></mdc>
         <message><fieldName>message</fieldName></message>
+
+        <!-- 여기서 MDC 통째 출력 금지 -->
         <provider class="_ganzi.codoc.global.log.LogstashFixedSchemaProvider"/>
       </providers>
     </encoder>
   </appender>
 
+  <!-- 4) ERROR JSON -->
   <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${LOG_DIR}/error.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -37,23 +53,29 @@
       <providers>
         <timestamp><fieldName>timestamp</fieldName></timestamp>
         <logLevel><fieldName>level</fieldName></logLevel>
-        <mdc><fieldName>_mdc</fieldName></mdc>
         <message><fieldName>message</fieldName></message>
+
+        <!-- stacktrace는 error.log에서만 1번 -->
         <stackTrace><fieldName>stacktrace</fieldName></stackTrace>
+
         <provider class="_ganzi.codoc.global.log.LogstashFixedSchemaProvider"/>
       </providers>
     </encoder>
   </appender>
 
+  <!-- ACCESS_LOG는 access.log -->
   <logger name="ACCESS_LOG" level="INFO" additivity="false">
     <appender-ref ref="ACCESS_FILE"/>
   </logger>
 
+  <!-- ERROR_LOG는 error.log -->
   <logger name="ERROR_LOG" level="INFO" additivity="false">
     <appender-ref ref="ERROR_FILE"/>
   </logger>
 
+  <!-- root: 프레임워크/부팅 로그는 app.log(+콘솔)로 -->
   <root level="INFO">
+    <appender-ref ref="APP_FILE"/>
     <appender-ref ref="CONSOLE"/>
   </root>
 


### PR DESCRIPTION
- LoggingContextFilter를 최상단에 등록
- 401/403/404 포함 status 기반 에러 로깅 보장
- MDC는 컨텍스트로만 사용하고 출력 중복 제거
- app.log를 logback root에서 직접 관리

## #️⃣ 연관된 이슈
- #[Issue number]
- close : #[Issue number]
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 내용 1
- 내용 2

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
