### PR TITLE
[feat] 회원 휴먼 처리 배치 추가

### DIFF
--- a/src/main/java/_ganzi/codoc/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/_ganzi/codoc/auth/repository/RefreshTokenRepository.java
@@ -2,8 +2,12 @@ package _ganzi.codoc.auth.repository;
 
 import _ganzi.codoc.auth.domain.RefreshToken;
 import _ganzi.codoc.user.domain.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
@@ -14,4 +18,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     void deleteByTokenValue(String tokenValue);
 
     void deleteByUser(User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from RefreshToken r where r.user.id in :userIds")
+    void deleteByUserIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/_ganzi/codoc/auth/service/KakaoAuthService.java
+++ b/src/main/java/_ganzi/codoc/auth/service/KakaoAuthService.java
@@ -82,7 +82,7 @@ public class KakaoAuthService {
             return authTokenService.issueTokenPairInternal(newUser);
         }
         if (user.getStatus() == UserStatus.DORMANT) {
-            user.reviveFromDormant();
+            userService.reviveDormantUser(user.getId());
         }
         return authTokenService.issueTokenPairInternal(user);
     }

--- a/src/main/java/_ganzi/codoc/user/domain/User.java
+++ b/src/main/java/_ganzi/codoc/user/domain/User.java
@@ -11,7 +11,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user")
+@Table(
+        name = "user",
+        indexes = {@Index(name = "idx_user_status_last_access", columnList = "status,last_access")})
 @Entity
 public class User {
 

--- a/src/main/java/_ganzi/codoc/user/repository/UserRepository.java
+++ b/src/main/java/_ganzi/codoc/user/repository/UserRepository.java
@@ -6,12 +6,28 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findAllByStatus(UserStatus status);
 
     List<User> findAllByStatusAndLastAccessBefore(UserStatus status, Instant lastAccess);
+
+    @Query("select u.id from User u where u.status = :status and u.lastAccess < :cutoff")
+    List<Long> findIdsByStatusAndLastAccessBefore(
+            @Param("status") UserStatus status, @Param("cutoff") Instant cutoff);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update User u set u.status = :toStatus "
+                    + "where u.status = :fromStatus and u.lastAccess < :cutoff")
+    int bulkUpdateStatusByLastAccessBefore(
+            @Param("fromStatus") UserStatus fromStatus,
+            @Param("toStatus") UserStatus toStatus,
+            @Param("cutoff") Instant cutoff);
 
     Optional<User> findByIdAndStatus(Long id, UserStatus status);
 

--- a/src/main/java/_ganzi/codoc/user/service/UserDormantScheduler.java
+++ b/src/main/java/_ganzi/codoc/user/service/UserDormantScheduler.java
@@ -1,0 +1,19 @@
+package _ganzi.codoc.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDormantScheduler {
+
+    private static final int DORMANT_AFTER_DAYS = 30;
+
+    private final UserService userService;
+
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
+    public void markDormantUsers() {
+        userService.markDormantUsersInactiveForDays(DORMANT_AFTER_DAYS);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈


<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 매일 01:00 AM 30일 이상 미접속 ACTIVE 유저 DORMANT 처리 (+refresh token 만료 처리)
- 소셜 로그인 시점에 ACTIVE로 전환, 일일 퀘스트 발급

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
