### PR TITLE
[fix] 토큰 재발급 시 최종 접속 시간 갱신

### DIFF
--- a/src/main/java/_ganzi/codoc/auth/service/AuthTokenService.java
+++ b/src/main/java/_ganzi/codoc/auth/service/AuthTokenService.java
@@ -30,6 +30,7 @@ public class AuthTokenService {
 
     @Transactional
     public TokenPair issueTokenPairInternal(User user) {
+        user.touchLastAccess();
         UserStatus status = user.getStatus();
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), status);
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), status);
@@ -64,6 +65,7 @@ public class AuthTokenService {
             throw new AuthRequiredException();
         }
         User user = refreshToken.getUser();
+        user.touchLastAccess();
         UserStatus status = user.getStatus();
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), status);


### PR DESCRIPTION
## #️⃣ 연관된 이슈


<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
사용자의 최종 접속시간이 갱신되고 있지 않은 문제를 DB에서 확인했습니다.
토큰 재발급 시 갱신 로직의 누락을 발견했습니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
