### PR TITLE
[feat] 챗봇 채팅 API를 하나의 POST 엔드포인트로 통합

### DIFF
--- a/src/main/java/_ganzi/codoc/chatbot/api/ChatbotApi.java
+++ b/src/main/java/_ganzi/codoc/chatbot/api/ChatbotApi.java
@@ -2,24 +2,21 @@ package _ganzi.codoc.chatbot.api;
 
 import _ganzi.codoc.auth.domain.AuthUser;
 import _ganzi.codoc.chatbot.dto.ChatbotMessageSendRequest;
-import _ganzi.codoc.chatbot.dto.ChatbotMessageSendResponse;
 import _ganzi.codoc.chatbot.exception.ChatbotErrorCode;
 import _ganzi.codoc.global.api.docs.ErrorCodes;
-import _ganzi.codoc.global.dto.ApiResponse;
 import _ganzi.codoc.global.exception.GlobalErrorCode;
 import _ganzi.codoc.problem.exception.ProblemErrorCode;
 import _ganzi.codoc.user.exception.UserErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import reactor.core.publisher.Flux;
 
 @Tag(name = "Chatbot", description = "Chatbot messaging endpoints")
 public interface ChatbotApi {
 
-    @Operation(summary = "Send chatbot message")
+    @Operation(summary = "Send and stream chatbot message (WebFlux)")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "400",
@@ -29,7 +26,7 @@ public interface ChatbotApi {
                 description = "AUTH_REQUIRED, UNAUTHORIZED"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "403",
-                description = "FORBIDDEN"),
+                description = "FORBIDDEN, CHATBOT_CONVERSATION_NO_PERMISSION"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "404",
                 description = "PROBLEM_NOT_FOUND, USER_NOT_FOUND"),
@@ -45,37 +42,8 @@ public interface ChatbotApi {
                 GlobalErrorCode.FORBIDDEN,
                 GlobalErrorCode.INTERNAL_SERVER_ERROR
             },
+            chatbot = {ChatbotErrorCode.CHATBOT_STREAM_EVENT_FAILED},
             problem = {ProblemErrorCode.PROBLEM_NOT_FOUND},
             user = {UserErrorCode.USER_NOT_FOUND})
-    ResponseEntity<ApiResponse<ChatbotMessageSendResponse>> sendMessage(
-            AuthUser authUser, ChatbotMessageSendRequest request);
-
-    @Operation(summary = "Stream chatbot message")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "401",
-                description = "AUTH_REQUIRED, UNAUTHORIZED"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "FORBIDDEN, CHATBOT_CONVERSATION_NO_PERMISSION"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "CHATBOT_CONVERSATION_NOT_FOUND"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "500",
-                description = "INTERNAL_SERVER_ERROR")
-    })
-    @ErrorCodes(
-            global = {
-                GlobalErrorCode.AUTH_REQUIRED,
-                GlobalErrorCode.UNAUTHORIZED,
-                GlobalErrorCode.FORBIDDEN,
-                GlobalErrorCode.INTERNAL_SERVER_ERROR
-            },
-            chatbot = {
-                ChatbotErrorCode.CHATBOT_CONVERSATION_NOT_FOUND,
-                ChatbotErrorCode.CHATBOT_CONVERSATION_NO_PERMISSION,
-                ChatbotErrorCode.CHATBOT_STREAM_EVENT_FAILED
-            })
-    Flux<ServerSentEvent<String>> streamMessage(AuthUser authUser, Long conversationId);
+    Flux<ServerSentEvent<String>> sendAndStream(AuthUser authUser, ChatbotMessageSendRequest request);
 }

--- a/src/main/java/_ganzi/codoc/chatbot/api/ChatbotController.java
+++ b/src/main/java/_ganzi/codoc/chatbot/api/ChatbotController.java
@@ -2,13 +2,10 @@ package _ganzi.codoc.chatbot.api;
 
 import _ganzi.codoc.auth.domain.AuthUser;
 import _ganzi.codoc.chatbot.dto.ChatbotMessageSendRequest;
-import _ganzi.codoc.chatbot.dto.ChatbotMessageSendResponse;
 import _ganzi.codoc.chatbot.service.ChatbotService;
-import _ganzi.codoc.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -21,23 +18,10 @@ public class ChatbotController implements ChatbotApi {
 
     private final ChatbotService chatbotService;
 
-    @Override
-    @PostMapping("/messages")
-    public ResponseEntity<ApiResponse<ChatbotMessageSendResponse>> sendMessage(
+    @PostMapping(value = "/messages/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<String>> sendAndStream(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody ChatbotMessageSendRequest request) {
-
-        ChatbotMessageSendResponse response = chatbotService.sendMessage(authUser.userId(), request);
-
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    @Override
-    @GetMapping(
-            value = "/messages/{conversationId}/stream",
-            produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ServerSentEvent<String>> streamMessage(
-            @AuthenticationPrincipal AuthUser authUser, @PathVariable Long conversationId) {
-        return chatbotService.streamMessage(authUser.userId(), conversationId);
+        return chatbotService.sendAndStream(authUser.userId(), request);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 기존 챗봇 채팅 API는 메시지 전송을 위한 POST 엔드포인트, 스트림을 위한 GET 엔드포인트로 나뉘었습니다.
- 하지만 하나의 POST 요청으로 처리하는 게 더 자연스럽고 SSE 중복 연결을 방지할 수 있다고 판단했습니다.
- 추후 AI 서버에서도 하나의 POST 엔드포인트로 통합하면 외부 API 호출 코드를 수정해야 합니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
