### PR TITLE
[feat] AI 추천 문제 해결 일일 퀘스트 추가.

### DIFF
--- a/src/main/java/_ganzi/codoc/problem/repository/RecommendedProblemRepository.java
+++ b/src/main/java/_ganzi/codoc/problem/repository/RecommendedProblemRepository.java
@@ -13,6 +13,8 @@ public interface RecommendedProblemRepository extends JpaRepository<RecommendedP
 
     long countByUserIdAndIsDoneFalse(Long userId);
 
+    long countByUserIdAndSolvedAtBetween(Long userId, Instant start, Instant end);
+
     @Query(
             "select rp.problem.id from RecommendedProblem rp "
                     + "where rp.user.id = :userId and rp.isDone = false")

--- a/src/main/java/_ganzi/codoc/user/service/requirements/RecommendedSolvedDailyCountRequirementEvaluator.java
+++ b/src/main/java/_ganzi/codoc/user/service/requirements/RecommendedSolvedDailyCountRequirementEvaluator.java
@@ -1,0 +1,39 @@
+package _ganzi.codoc.user.service.requirements;
+
+import _ganzi.codoc.problem.repository.RecommendedProblemRepository;
+import _ganzi.codoc.user.domain.UserQuest;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+
+@Component
+@RequiredArgsConstructor
+public class RecommendedSolvedDailyCountRequirementEvaluator implements QuestRequirementEvaluator {
+
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final RecommendedProblemRepository recommendedProblemRepository;
+
+    @Override
+    public String key() {
+        return "RECOMMENDED_SOLVED_DAILY_COUNT";
+    }
+
+    @Override
+    public boolean isSatisfied(UserQuest userQuest, JsonNode value) {
+        int required = value.asInt(0);
+        if (required <= 0) {
+            return false;
+        }
+        LocalDate today = LocalDate.now(DEFAULT_ZONE);
+        Instant start = today.atStartOfDay(DEFAULT_ZONE).toInstant();
+        Instant end = today.plusDays(1).atStartOfDay(DEFAULT_ZONE).toInstant();
+        long solvedCount =
+                recommendedProblemRepository.countByUserIdAndSolvedAtBetween(
+                        userQuest.getUser().getId(), start, end);
+        return solvedCount >= required;
+    }
+}

--- a/src/main/resources/db/migration/R__seed_core_data.sql
+++ b/src/main/resources/db/migration/R__seed_core_data.sql
@@ -37,3 +37,28 @@ WHERE NOT EXISTS (SELECT 1 FROM avatar WHERE name = 'profile8');
 INSERT INTO avatar (created_at, updated_at, name, image_url, is_default)
 SELECT NOW(6), NOW(6), 'profile9', 'https://codoc.cloud/images/profile9.png', b'0'
 WHERE NOT EXISTS (SELECT 1 FROM avatar WHERE name = 'profile9');
+
+-- Daily quests
+INSERT INTO quest (created_at, updated_at, title, requirements, issue_conditions, reward, type, duration)
+SELECT NOW(6), NOW(6), '오늘의 첫 문제 해결', JSON_OBJECT('DailySolvedCount', 1), NULL, 10, 'DAILY', 1
+WHERE NOT EXISTS (SELECT 1 FROM quest WHERE title = '오늘의 첫 문제 해결');
+
+INSERT INTO quest (created_at, updated_at, title, requirements, issue_conditions, reward, type, duration)
+SELECT NOW(6), NOW(6), '일일 목표 달성 목표: 1문제', JSON_OBJECT('DailySolvedCount', 1),
+       JSON_OBJECT('DailyGoal', 'ONE'), 10, 'DAILY', 1
+WHERE NOT EXISTS (SELECT 1 FROM quest WHERE title = '일일 목표 달성 목표: 1문제');
+
+INSERT INTO quest (created_at, updated_at, title, requirements, issue_conditions, reward, type, duration)
+SELECT NOW(6), NOW(6), '일일 목표 달성 목표: 3문제', JSON_OBJECT('DailySolvedCount', 3),
+       JSON_OBJECT('DailyGoal', 'THREE'), 30, 'DAILY', 1
+WHERE NOT EXISTS (SELECT 1 FROM quest WHERE title = '일일 목표 달성 목표: 3문제');
+
+INSERT INTO quest (created_at, updated_at, title, requirements, issue_conditions, reward, type, duration)
+SELECT NOW(6), NOW(6), '일일 목표 달성 목표: 5문제', JSON_OBJECT('DailySolvedCount', 5),
+       JSON_OBJECT('DailyGoal', 'FIVE'), 50, 'DAILY', 1
+WHERE NOT EXISTS (SELECT 1 FROM quest WHERE title = '일일 목표 달성 목표: 5문제');
+
+INSERT INTO quest (created_at, updated_at, title, requirements, issue_conditions, reward, type, duration)
+SELECT NOW(6), NOW(6), '추천 문제 해결 (일일)',
+       JSON_OBJECT('RECOMMENDED_SOLVED_DAILY_COUNT', 1), NULL, 50, 'DAILY', 1
+WHERE NOT EXISTS (SELECT 1 FROM quest WHERE title = '추천 문제 해결 (일일)');


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #[Issue number]
- close : #[Issue number]
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->

- 요구사항 키/쿼리 기준 확정 반영: RECOMMENDED_SOLVED_DAILY_COUNT, solved_at(UTC) + Asia/Seoul 날짜 범위
- 추천 문제 일일 카운트용 리포지토리 쿼리 추가( user_id + solved_at between start/end )
- 퀘스트 evaluator registry에 RECOMMENDED_SOLVED_DAILY_COUNT 연결 및 카운트 계산 로직 추가
- 퀘스트 완료 갱신 흐름에 적용(추천 문제 solve 후 refreshUserQuestStatuses 호출 유지)
- 테스트 추가(일일 카운트 evaluator, 퀘스트 완료 시나리오)
- Flyway에 퀘스트 5개 seed 추가

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
