### PR TITLE
[fix] PR에서는 린트를 비활성화하고 push에서만 실행하도록 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,11 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Checkstyle
+        if: github.event_name == 'push'
         run: ./gradlew checkstyleMain
 
       - name: Check format
+        if: github.event_name == 'push'
         run: ./gradlew spotlessCheck
 
       # 빌드 (Spring Boot JAR 생성)


### PR DESCRIPTION
## 📝 작업 내용
- PR 단계에서는 ESLint 린트가 실행되지 않도록 조건 추가
- develop / main 브랜치에 push될 때만 린트가 실행되도록 CI 정책 수정
- PR 속도 개선 및 불필요한 CI 리소스 사용 방지
