### PR TITLE
[feat] 알림 엔티티 생성

### DIFF
--- a/src/main/java/_ganzi/codoc/notification/domain/Notification.java
+++ b/src/main/java/_ganzi/codoc/notification/domain/Notification.java
@@ -1,0 +1,95 @@
+package _ganzi.codoc.notification.domain;
+
+import _ganzi.codoc.notification.enums.LinkCode;
+import _ganzi.codoc.notification.enums.NotificationType;
+import _ganzi.codoc.notification.infra.LinkParamsConverter;
+import _ganzi.codoc.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "notification")
+@Entity
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(name = "title", nullable = false, length = 120)
+    private String title;
+
+    @Column(name = "body", nullable = false, length = 1000)
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "link_code", nullable = false, length = 30)
+    private LinkCode linkCode;
+
+    @Convert(converter = LinkParamsConverter.class)
+    @Column(name = "link_params", columnDefinition = "json")
+    private Map<String, String> linkParams;
+
+    @Column(name = "read_at")
+    private Instant readAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    private Notification(
+            User user,
+            NotificationType type,
+            String title,
+            String body,
+            LinkCode linkCode,
+            Map<String, String> linkParams) {
+        this.user = user;
+        this.type = type;
+        this.title = title;
+        this.body = body;
+        this.linkCode = linkCode;
+        this.linkParams = linkParams == null ? Map.of() : Map.copyOf(linkParams);
+    }
+
+    public static Notification create(
+            User user,
+            NotificationType type,
+            String title,
+            String body,
+            LinkCode linkCode,
+            Map<String, String> linkParams) {
+        return new Notification(user, type, title, body, linkCode, linkParams);
+    }
+}

--- a/src/main/java/_ganzi/codoc/notification/domain/UserDevice.java
+++ b/src/main/java/_ganzi/codoc/notification/domain/UserDevice.java
@@ -1,0 +1,55 @@
+package _ganzi.codoc.notification.domain;
+
+import _ganzi.codoc.global.domain.BaseTimeEntity;
+import _ganzi.codoc.notification.enums.DevicePlatform;
+import _ganzi.codoc.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_device")
+@Entity
+public class UserDevice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", nullable = false, length = 20)
+    private DevicePlatform platform;
+
+    @Column(name = "push_token", nullable = false, length = 512)
+    private String pushToken;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    private UserDevice(User user, DevicePlatform platform, String pushToken) {
+        this.user = user;
+        this.platform = platform;
+        this.pushToken = pushToken;
+        this.active = true;
+    }
+
+    public static UserDevice create(User user, DevicePlatform platform, String pushToken) {
+        return new UserDevice(user, platform, pushToken);
+    }
+}

--- a/src/main/java/_ganzi/codoc/notification/domain/UserNotificationPreference.java
+++ b/src/main/java/_ganzi/codoc/notification/domain/UserNotificationPreference.java
@@ -1,0 +1,52 @@
+package _ganzi.codoc.notification.domain;
+
+import _ganzi.codoc.global.domain.BaseTimeEntity;
+import _ganzi.codoc.notification.enums.NotificationType;
+import _ganzi.codoc.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_notification_preference")
+@Entity
+public class UserNotificationPreference extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled;
+
+    private UserNotificationPreference(User user, NotificationType type, boolean enabled) {
+        this.user = user;
+        this.type = type;
+        this.enabled = enabled;
+    }
+
+    public static UserNotificationPreference create(
+            User user, NotificationType type, boolean enabled) {
+        return new UserNotificationPreference(user, type, enabled);
+    }
+}

--- a/src/main/java/_ganzi/codoc/notification/enums/DevicePlatform.java
+++ b/src/main/java/_ganzi/codoc/notification/enums/DevicePlatform.java
@@ -1,0 +1,7 @@
+package _ganzi.codoc.notification.enums;
+
+public enum DevicePlatform {
+    ANDROID,
+    IOS,
+    WEB
+}

--- a/src/main/java/_ganzi/codoc/notification/enums/LinkCode.java
+++ b/src/main/java/_ganzi/codoc/notification/enums/LinkCode.java
@@ -1,0 +1,8 @@
+package _ganzi.codoc.notification.enums;
+
+public enum LinkCode {
+    HOME,
+    MY,
+    LEADERBOARD,
+    ;
+}

--- a/src/main/java/_ganzi/codoc/notification/enums/NotificationType.java
+++ b/src/main/java/_ganzi/codoc/notification/enums/NotificationType.java
@@ -1,0 +1,17 @@
+package _ganzi.codoc.notification.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    ATTENDANCE(false, LinkCode.HOME),
+    AI_RECOMMENDED_PROBLEM_ISSUED(true, LinkCode.HOME),
+    AI_ANALYSIS_REPORT_CREATED(true, LinkCode.MY),
+    LEADERBOARD_CLOSED(true, LinkCode.LEADERBOARD),
+    ;
+
+    private final boolean inboxVisible;
+    private final LinkCode linkCode;
+}

--- a/src/main/java/_ganzi/codoc/notification/infra/LinkParamsConverter.java
+++ b/src/main/java/_ganzi/codoc/notification/infra/LinkParamsConverter.java
@@ -1,0 +1,42 @@
+package _ganzi.codoc.notification.infra;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.io.IOException;
+import java.util.Map;
+
+@Converter
+public class LinkParamsConverter implements AttributeConverter<Map<String, String>, String> {
+
+    private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+    private static final TypeReference<Map<String, String>> TYPE_REFERENCE = new TypeReference<>() {};
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return JSON_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("Failed to serialize link params.", exception);
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Map.of();
+        }
+
+        try {
+            return JSON_MAPPER.readValue(dbData, TYPE_REFERENCE);
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("Failed to deserialize link params.", exception);
+        }
+    }
+}

--- a/src/main/resources/db/migration/V4__add_notification_tables.sql
+++ b/src/main/resources/db/migration/V4__add_notification_tables.sql
@@ -1,0 +1,40 @@
+CREATE TABLE `notification` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint NOT NULL,
+  `type` varchar(30) NOT NULL,
+  `title` varchar(120) NOT NULL,
+  `body` varchar(1000) NOT NULL,
+  `link_code` varchar(30) NOT NULL,
+  `link_params` json DEFAULT NULL,
+  `read_at` timestamp(6) NULL DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL,
+  `deleted_at` timestamp(6) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_notification_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `user_device` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint NOT NULL,
+  `platform` varchar(20) NOT NULL,
+  `push_token` varchar(512) NOT NULL,
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
+  `created_at` timestamp(6) NOT NULL,
+  `updated_at` timestamp(6) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_user_device_user_id` (`user_id`),
+  UNIQUE KEY `uk_user_device_push_token` (`push_token`),
+  CONSTRAINT `fk_user_device_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `user_notification_preference` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint NOT NULL,
+  `type` varchar(30) NOT NULL,
+  `enabled` tinyint(1) NOT NULL DEFAULT 1,
+  `created_at` timestamp(6) NOT NULL,
+  `updated_at` timestamp(6) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_user_notification_preference` (`user_id`,`type`),
+  CONSTRAINT `fk_user_notification_preference_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #252 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 알림 기능 구현에 필요한 엔티티를 생성했습니다.

1. Notification

- 사용자 알림함에 저장되는 알림 이력
- linkCode + linkParams: 알림 클릭 시 이동할 주소. linkCode는 정적 주소, linkParams는 경로 변수 등 동적 주소

2. UserDevice

- 푸시를 실제로 보낼 사용자 디바이스 정보
- 현재는 유저당 단일 디바이스 정책 사용

3. UserNotificationPreference

- 사용자별 푸시 알림 수신 여부
- 알림 유형별로 설정 가능

4. NotificationType

- inboxVisible: true면 알림 페이지에서 조회 가능


## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
