### PR TITLE
[feat] 유저 디바이스 등록/해제 API 구현

### DIFF
--- a/src/main/java/_ganzi/codoc/notification/api/NotificationDeviceApi.java
+++ b/src/main/java/_ganzi/codoc/notification/api/NotificationDeviceApi.java
@@ -1,0 +1,71 @@
+package _ganzi.codoc.notification.api;
+
+import _ganzi.codoc.auth.domain.AuthUser;
+import _ganzi.codoc.global.api.docs.ErrorCodes;
+import _ganzi.codoc.global.exception.GlobalErrorCode;
+import _ganzi.codoc.notification.dto.NotificationDeviceRegisterRequest;
+import _ganzi.codoc.user.exception.UserErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Notification Device", description = "Notification device endpoints")
+public interface NotificationDeviceApi {
+
+    @Operation(summary = "Register or update notification device")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "INVALID_INPUT"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "AUTH_REQUIRED, UNAUTHORIZED"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "USER_NOT_FOUND"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "INTERNAL_SERVER_ERROR")
+    })
+    @ErrorCodes(
+            global = {
+                GlobalErrorCode.INVALID_INPUT,
+                GlobalErrorCode.AUTH_REQUIRED,
+                GlobalErrorCode.UNAUTHORIZED,
+                GlobalErrorCode.FORBIDDEN,
+                GlobalErrorCode.INTERNAL_SERVER_ERROR
+            },
+            user = {UserErrorCode.USER_NOT_FOUND})
+    ResponseEntity<Void> registerDevice(
+            AuthUser authUser, @Valid NotificationDeviceRegisterRequest request);
+
+    @Operation(summary = "Deactivate notification devices for current user")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "INVALID_INPUT"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "AUTH_REQUIRED, UNAUTHORIZED"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "INTERNAL_SERVER_ERROR")
+    })
+    @ErrorCodes(
+            global = {
+                GlobalErrorCode.INVALID_INPUT,
+                GlobalErrorCode.AUTH_REQUIRED,
+                GlobalErrorCode.UNAUTHORIZED,
+                GlobalErrorCode.FORBIDDEN,
+                GlobalErrorCode.INTERNAL_SERVER_ERROR
+            })
+    ResponseEntity<Void> deactivateDevice(AuthUser authUser);
+}

--- a/src/main/java/_ganzi/codoc/notification/api/NotificationDeviceController.java
+++ b/src/main/java/_ganzi/codoc/notification/api/NotificationDeviceController.java
@@ -1,0 +1,40 @@
+package _ganzi.codoc.notification.api;
+
+import _ganzi.codoc.auth.domain.AuthUser;
+import _ganzi.codoc.notification.dto.NotificationDeviceRegisterRequest;
+import _ganzi.codoc.notification.service.UserDeviceService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/notification-devices")
+@RestController
+public class NotificationDeviceController implements NotificationDeviceApi {
+
+    private final UserDeviceService userDeviceService;
+
+    @Override
+    @PutMapping
+    public ResponseEntity<Void> registerDevice(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody NotificationDeviceRegisterRequest request) {
+        userDeviceService.registerDevice(authUser.userId(), request.platform(), request.pushToken());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @DeleteMapping
+    public ResponseEntity<Void> deactivateDevice(@AuthenticationPrincipal AuthUser authUser) {
+        userDeviceService.deactivateDevice(authUser.userId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/_ganzi/codoc/notification/domain/UserDevice.java
+++ b/src/main/java/_ganzi/codoc/notification/domain/UserDevice.java
@@ -52,4 +52,15 @@ public class UserDevice extends BaseTimeEntity {
     public static UserDevice create(User user, DevicePlatform platform, String pushToken) {
         return new UserDevice(user, platform, pushToken);
     }
+
+    public void updateRegistration(User user, DevicePlatform platform, String pushToken) {
+        this.user = user;
+        this.platform = platform;
+        this.pushToken = pushToken;
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
 }

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationDeviceRegisterRequest.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationDeviceRegisterRequest.java
@@ -1,0 +1,12 @@
+package _ganzi.codoc.notification.dto;
+
+import _ganzi.codoc.notification.enums.DevicePlatform;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NotificationDeviceRegisterRequest(
+        @NotNull(message = "디바이스 플랫폼 값이 유효하지 않습니다.") DevicePlatform platform,
+        @NotBlank(message = "푸시 토큰은 비어 있을 수 없습니다.")
+                @Size(max = 512, message = "푸시 토큰 길이는 512자를 초과할 수 없습니다.")
+                String pushToken) {}

--- a/src/main/java/_ganzi/codoc/notification/repository/UserDeviceRepository.java
+++ b/src/main/java/_ganzi/codoc/notification/repository/UserDeviceRepository.java
@@ -1,0 +1,10 @@
+package _ganzi.codoc.notification.repository;
+
+import _ganzi.codoc.notification.domain.UserDevice;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+
+    Optional<UserDevice> findByUserId(Long userId);
+}

--- a/src/main/java/_ganzi/codoc/notification/service/UserDeviceService.java
+++ b/src/main/java/_ganzi/codoc/notification/service/UserDeviceService.java
@@ -1,0 +1,36 @@
+package _ganzi.codoc.notification.service;
+
+import _ganzi.codoc.notification.domain.UserDevice;
+import _ganzi.codoc.notification.enums.DevicePlatform;
+import _ganzi.codoc.notification.repository.UserDeviceRepository;
+import _ganzi.codoc.user.domain.User;
+import _ganzi.codoc.user.exception.UserNotFoundException;
+import _ganzi.codoc.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserDeviceService {
+
+    private final UserRepository userRepository;
+    private final UserDeviceRepository userDeviceRepository;
+
+    @Transactional
+    public void registerDevice(Long userId, DevicePlatform platform, String pushToken) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        userDeviceRepository
+                .findByUserId(userId)
+                .ifPresentOrElse(
+                        device -> device.updateRegistration(user, platform, pushToken),
+                        () -> userDeviceRepository.save(UserDevice.create(user, platform, pushToken)));
+    }
+
+    @Transactional
+    public void deactivateDevice(Long userId) {
+        userDeviceRepository.findByUserId(userId).ifPresent(UserDevice::deactivate);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #255 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 푸시 알림을 수신할 유저 디바이스를 등록 및 해제하는 API를 구현했습니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
