### PR TITLE
[feat] 푸시 알림 수신 설정 API 구현

### DIFF
--- a/src/main/java/_ganzi/codoc/notification/api/NotificationPreferenceApi.java
+++ b/src/main/java/_ganzi/codoc/notification/api/NotificationPreferenceApi.java
@@ -1,0 +1,73 @@
+package _ganzi.codoc.notification.api;
+
+import _ganzi.codoc.auth.domain.AuthUser;
+import _ganzi.codoc.global.api.docs.ErrorCodes;
+import _ganzi.codoc.global.dto.ApiResponse;
+import _ganzi.codoc.global.exception.GlobalErrorCode;
+import _ganzi.codoc.notification.dto.NotificationPreferenceResponse;
+import _ganzi.codoc.notification.dto.NotificationPreferenceUpdateRequest;
+import _ganzi.codoc.user.exception.UserErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Notification Preference", description = "Notification preference endpoints")
+public interface NotificationPreferenceApi {
+
+    @Operation(summary = "Get notification preferences")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "AUTH_REQUIRED, UNAUTHORIZED"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "USER_NOT_FOUND"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "INTERNAL_SERVER_ERROR")
+    })
+    @ErrorCodes(
+            global = {
+                GlobalErrorCode.AUTH_REQUIRED,
+                GlobalErrorCode.UNAUTHORIZED,
+                GlobalErrorCode.FORBIDDEN,
+                GlobalErrorCode.INTERNAL_SERVER_ERROR
+            },
+            user = {UserErrorCode.USER_NOT_FOUND})
+    ResponseEntity<ApiResponse<NotificationPreferenceResponse>> getPreferences(AuthUser authUser);
+
+    @Operation(summary = "Update notification preference")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "INVALID_INPUT"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "AUTH_REQUIRED, UNAUTHORIZED"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "USER_NOT_FOUND"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "INTERNAL_SERVER_ERROR")
+    })
+    @ErrorCodes(
+            global = {
+                GlobalErrorCode.INVALID_INPUT,
+                GlobalErrorCode.AUTH_REQUIRED,
+                GlobalErrorCode.UNAUTHORIZED,
+                GlobalErrorCode.FORBIDDEN,
+                GlobalErrorCode.INTERNAL_SERVER_ERROR
+            },
+            user = {UserErrorCode.USER_NOT_FOUND})
+    ResponseEntity<Void> updatePreference(
+            AuthUser authUser, @Valid NotificationPreferenceUpdateRequest request);
+}

--- a/src/main/java/_ganzi/codoc/notification/api/NotificationPreferenceController.java
+++ b/src/main/java/_ganzi/codoc/notification/api/NotificationPreferenceController.java
@@ -1,0 +1,39 @@
+package _ganzi.codoc.notification.api;
+
+import _ganzi.codoc.auth.domain.AuthUser;
+import _ganzi.codoc.global.dto.ApiResponse;
+import _ganzi.codoc.notification.dto.NotificationPreferenceResponse;
+import _ganzi.codoc.notification.dto.NotificationPreferenceUpdateRequest;
+import _ganzi.codoc.notification.service.UserNotificationPreferenceService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/notification-preferences")
+@RestController
+public class NotificationPreferenceController implements NotificationPreferenceApi {
+
+    private final UserNotificationPreferenceService preferenceService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<NotificationPreferenceResponse>> getPreferences(
+            @AuthenticationPrincipal AuthUser authUser) {
+        return ResponseEntity.ok(
+                ApiResponse.success(preferenceService.getPreferences(authUser.userId())));
+    }
+
+    @Override
+    @PatchMapping
+    public ResponseEntity<Void> updatePreference(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody NotificationPreferenceUpdateRequest request) {
+        preferenceService.updatePreference(authUser.userId(), request.type(), request.enabled());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/_ganzi/codoc/notification/domain/UserNotificationPreference.java
+++ b/src/main/java/_ganzi/codoc/notification/domain/UserNotificationPreference.java
@@ -49,4 +49,8 @@ public class UserNotificationPreference extends BaseTimeEntity {
             User user, NotificationType type, boolean enabled) {
         return new UserNotificationPreference(user, type, enabled);
     }
+
+    public void updateEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 }

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationPreferenceItem.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationPreferenceItem.java
@@ -1,0 +1,5 @@
+package _ganzi.codoc.notification.dto;
+
+import _ganzi.codoc.notification.enums.NotificationType;
+
+public record NotificationPreferenceItem(NotificationType type, boolean enabled) {}

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationPreferenceResponse.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationPreferenceResponse.java
@@ -1,0 +1,5 @@
+package _ganzi.codoc.notification.dto;
+
+import java.util.List;
+
+public record NotificationPreferenceResponse(List<NotificationPreferenceItem> preferences) {}

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationPreferenceUpdateRequest.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationPreferenceUpdateRequest.java
@@ -1,0 +1,8 @@
+package _ganzi.codoc.notification.dto;
+
+import _ganzi.codoc.notification.enums.NotificationType;
+import jakarta.validation.constraints.NotNull;
+
+public record NotificationPreferenceUpdateRequest(
+        @NotNull(message = "알림 종류 값이 유효하지 않습니다.") NotificationType type,
+        @NotNull(message = "알림 수신 여부 값이 유효하지 않습니다.") Boolean enabled) {}

--- a/src/main/java/_ganzi/codoc/notification/repository/UserNotificationPreferenceRepository.java
+++ b/src/main/java/_ganzi/codoc/notification/repository/UserNotificationPreferenceRepository.java
@@ -1,0 +1,15 @@
+package _ganzi.codoc.notification.repository;
+
+import _ganzi.codoc.notification.domain.UserNotificationPreference;
+import _ganzi.codoc.notification.enums.NotificationType;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserNotificationPreferenceRepository
+        extends JpaRepository<UserNotificationPreference, Long> {
+
+    List<UserNotificationPreference> findAllByUserId(Long userId);
+
+    Optional<UserNotificationPreference> findByUserIdAndType(Long userId, NotificationType type);
+}

--- a/src/main/java/_ganzi/codoc/notification/service/UserNotificationPreferenceService.java
+++ b/src/main/java/_ganzi/codoc/notification/service/UserNotificationPreferenceService.java
@@ -1,0 +1,67 @@
+package _ganzi.codoc.notification.service;
+
+import _ganzi.codoc.notification.domain.UserNotificationPreference;
+import _ganzi.codoc.notification.dto.NotificationPreferenceItem;
+import _ganzi.codoc.notification.dto.NotificationPreferenceResponse;
+import _ganzi.codoc.notification.enums.NotificationType;
+import _ganzi.codoc.notification.repository.UserNotificationPreferenceRepository;
+import _ganzi.codoc.user.domain.User;
+import _ganzi.codoc.user.exception.UserNotFoundException;
+import _ganzi.codoc.user.repository.UserRepository;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserNotificationPreferenceService {
+
+    private final UserNotificationPreferenceRepository userNotificationPreferenceRepository;
+    private final UserRepository userRepository;
+
+    public NotificationPreferenceResponse getPreferences(Long userId) {
+        userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        List<UserNotificationPreference> preferences =
+                userNotificationPreferenceRepository.findAllByUserId(userId);
+
+        return toPreferenceResponse(preferences);
+    }
+
+    @Transactional
+    public void updatePreference(Long userId, NotificationType type, boolean enabled) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        UserNotificationPreference preference =
+                userNotificationPreferenceRepository
+                        .findByUserIdAndType(userId, type)
+                        .orElseGet(
+                                () ->
+                                        userNotificationPreferenceRepository.save(
+                                                UserNotificationPreference.create(user, type, enabled)));
+
+        preference.updateEnabled(enabled);
+    }
+
+    private NotificationPreferenceResponse toPreferenceResponse(
+            List<UserNotificationPreference> preferences) {
+
+        Map<NotificationType, Boolean> enabledByType = new EnumMap<>(NotificationType.class);
+
+        for (UserNotificationPreference preference : preferences) {
+            enabledByType.put(preference.getType(), preference.isEnabled());
+        }
+
+        return new NotificationPreferenceResponse(
+                Arrays.stream(NotificationType.values())
+                        .map(
+                                type ->
+                                        new NotificationPreferenceItem(type, enabledByType.getOrDefault(type, true)))
+                        .toList());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #256 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 유저의 푸시 알림 수신 설정 조회 API, 특정 알림 유형의 푸시 알림 수신 설정 활성화 및 비활성화 API를 구현했습니다.
- 초기 상태가 활성화이고, 특정 알림 유형의 푸시 알림 수신 설정이 DB에 존재하지 않으면 활성화된 것으로 판단합니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
