### PR TITLE
[feat] 알림 조회/읽음 처리 API 구현

### DIFF
--- a/src/main/java/_ganzi/codoc/notification/api/NotificationApi.java
+++ b/src/main/java/_ganzi/codoc/notification/api/NotificationApi.java
@@ -1,0 +1,86 @@
+package _ganzi.codoc.notification.api;
+
+import _ganzi.codoc.auth.domain.AuthUser;
+import _ganzi.codoc.global.api.docs.ErrorCodes;
+import _ganzi.codoc.global.dto.ApiResponse;
+import _ganzi.codoc.global.exception.GlobalErrorCode;
+import _ganzi.codoc.notification.dto.NotificationReadRequest;
+import _ganzi.codoc.notification.dto.NotificationResponse;
+import _ganzi.codoc.notification.dto.NotificationUnreadStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Notification", description = "Notification endpoints")
+public interface NotificationApi {
+
+    @Operation(summary = "Get recent notifications (last 7 days)")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "AUTH_REQUIRED, UNAUTHORIZED"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "INTERNAL_SERVER_ERROR")
+    })
+    @ErrorCodes(
+            global = {
+                GlobalErrorCode.AUTH_REQUIRED,
+                GlobalErrorCode.UNAUTHORIZED,
+                GlobalErrorCode.FORBIDDEN,
+                GlobalErrorCode.INTERNAL_SERVER_ERROR
+            })
+    ResponseEntity<ApiResponse<NotificationResponse>> getRecentNotifications(AuthUser authUser);
+
+    @Operation(summary = "Check whether unread notifications exist (last 7 days)")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "AUTH_REQUIRED, UNAUTHORIZED"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "INTERNAL_SERVER_ERROR")
+    })
+    @ErrorCodes(
+            global = {
+                GlobalErrorCode.AUTH_REQUIRED,
+                GlobalErrorCode.UNAUTHORIZED,
+                GlobalErrorCode.FORBIDDEN,
+                GlobalErrorCode.INTERNAL_SERVER_ERROR
+            })
+    ResponseEntity<ApiResponse<NotificationUnreadStatusResponse>> getUnreadStatus(AuthUser authUser);
+
+    @Operation(summary = "Mark unread notifications as read")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "INVALID_INPUT"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "AUTH_REQUIRED, UNAUTHORIZED"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "INTERNAL_SERVER_ERROR")
+    })
+    @ErrorCodes(
+            global = {
+                GlobalErrorCode.INVALID_INPUT,
+                GlobalErrorCode.AUTH_REQUIRED,
+                GlobalErrorCode.UNAUTHORIZED,
+                GlobalErrorCode.FORBIDDEN,
+                GlobalErrorCode.INTERNAL_SERVER_ERROR
+            })
+    ResponseEntity<Void> markUnreadNotificationsAsRead(
+            AuthUser authUser, @Valid NotificationReadRequest request);
+}

--- a/src/main/java/_ganzi/codoc/notification/api/NotificationController.java
+++ b/src/main/java/_ganzi/codoc/notification/api/NotificationController.java
@@ -1,0 +1,53 @@
+package _ganzi.codoc.notification.api;
+
+import _ganzi.codoc.auth.domain.AuthUser;
+import _ganzi.codoc.global.dto.ApiResponse;
+import _ganzi.codoc.notification.dto.NotificationReadRequest;
+import _ganzi.codoc.notification.dto.NotificationResponse;
+import _ganzi.codoc.notification.dto.NotificationUnreadStatusResponse;
+import _ganzi.codoc.notification.service.NotificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+@RestController
+public class NotificationController implements NotificationApi {
+
+    private final NotificationService notificationService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<NotificationResponse>> getRecentNotifications(
+            @AuthenticationPrincipal AuthUser authUser) {
+        NotificationResponse response = notificationService.getRecentNotifications(authUser.userId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Override
+    @GetMapping("/unread-status")
+    public ResponseEntity<ApiResponse<NotificationUnreadStatusResponse>> getUnreadStatus(
+            @AuthenticationPrincipal AuthUser authUser) {
+        NotificationUnreadStatusResponse response =
+                notificationService.getUnreadStatus(authUser.userId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Override
+    @PatchMapping("/read-status")
+    public ResponseEntity<Void> markUnreadNotificationsAsRead(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody NotificationReadRequest request) {
+        notificationService.markAsRead(authUser.userId(), request.notificationIds());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationItem.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationItem.java
@@ -1,0 +1,28 @@
+package _ganzi.codoc.notification.dto;
+
+import _ganzi.codoc.notification.domain.Notification;
+import _ganzi.codoc.notification.enums.LinkCode;
+import _ganzi.codoc.notification.enums.NotificationType;
+import java.time.Instant;
+import java.util.Map;
+
+public record NotificationItem(
+        Long notificationId,
+        NotificationType type,
+        String title,
+        String body,
+        LinkCode linkCode,
+        Map<String, String> linkParams,
+        Instant createdAt) {
+
+    public static NotificationItem from(Notification notification) {
+        return new NotificationItem(
+                notification.getId(),
+                notification.getType(),
+                notification.getTitle(),
+                notification.getBody(),
+                notification.getLinkCode(),
+                notification.getLinkParams(),
+                notification.getCreatedAt());
+    }
+}

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationReadRequest.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationReadRequest.java
@@ -1,0 +1,11 @@
+package _ganzi.codoc.notification.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+public record NotificationReadRequest(
+        @NotEmpty(message = "알림 ID 목록은 비어 있을 수 없습니다.")
+                List<@NotNull(message = "알림 ID는 필수입니다.") @Positive(message = "알림 ID는 양수여야 합니다.") Long>
+                        notificationIds) {}

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationResponse.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationResponse.java
@@ -1,0 +1,5 @@
+package _ganzi.codoc.notification.dto;
+
+import java.util.List;
+
+public record NotificationResponse(List<NotificationItem> notifications) {}

--- a/src/main/java/_ganzi/codoc/notification/dto/NotificationUnreadStatusResponse.java
+++ b/src/main/java/_ganzi/codoc/notification/dto/NotificationUnreadStatusResponse.java
@@ -1,0 +1,3 @@
+package _ganzi.codoc.notification.dto;
+
+public record NotificationUnreadStatusResponse(boolean hasUnread) {}

--- a/src/main/java/_ganzi/codoc/notification/repository/NotificationRepository.java
+++ b/src/main/java/_ganzi/codoc/notification/repository/NotificationRepository.java
@@ -1,6 +1,49 @@
 package _ganzi.codoc.notification.repository;
 
 import _ganzi.codoc.notification.domain.Notification;
+import java.time.Instant;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {}
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query(
+            """
+            select n
+            from Notification n
+            where n.user.id = :userId
+              and n.createdAt >= :cutoff
+              and n.deletedAt is null
+            order by n.createdAt desc
+            """)
+    List<Notification> findRecentByUserId(
+            @Param("userId") Long userId, @Param("cutoff") Instant cutoff);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            """
+            update Notification n
+               set n.readAt = CURRENT_TIMESTAMP
+             where n.user.id = :userId
+               and n.id in :notificationIds
+               and n.readAt is null
+               and n.deletedAt is null
+            """)
+    void markAsReadByUserIdAndIds(
+            @Param("userId") Long userId, @Param("notificationIds") List<Long> notificationIds);
+
+    @Query(
+            """
+            select case when count(n) > 0 then true else false end
+            from Notification n
+            where n.user.id = :userId
+              and n.readAt is null
+              and n.createdAt >= :cutoff
+              and n.deletedAt is null
+            """)
+    boolean existsUnreadRecentByUserId(
+            @Param("userId") Long userId, @Param("cutoff") Instant cutoff);
+}

--- a/src/main/java/_ganzi/codoc/notification/service/NotificationService.java
+++ b/src/main/java/_ganzi/codoc/notification/service/NotificationService.java
@@ -1,0 +1,53 @@
+package _ganzi.codoc.notification.service;
+
+import _ganzi.codoc.notification.dto.NotificationItem;
+import _ganzi.codoc.notification.dto.NotificationResponse;
+import _ganzi.codoc.notification.dto.NotificationUnreadStatusResponse;
+import _ganzi.codoc.notification.repository.NotificationRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class NotificationService {
+
+    private static final Duration INBOX_RETENTION = Duration.ofDays(7);
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationResponse getRecentNotifications(Long userId) {
+        Instant cutoff = cutoff();
+
+        List<NotificationItem> notifications =
+                notificationRepository.findRecentByUserId(userId, cutoff).stream()
+                        .map(NotificationItem::from)
+                        .toList();
+
+        return new NotificationResponse(notifications);
+    }
+
+    public NotificationUnreadStatusResponse getUnreadStatus(Long userId) {
+        boolean hasUnread = notificationRepository.existsUnreadRecentByUserId(userId, cutoff());
+        return new NotificationUnreadStatusResponse(hasUnread);
+    }
+
+    @Transactional
+    public void markAsRead(Long userId, List<Long> notificationIds) {
+        List<Long> distinctNotificationIds = notificationIds.stream().distinct().toList();
+
+        if (distinctNotificationIds.isEmpty()) {
+            return;
+        }
+
+        notificationRepository.markAsReadByUserIdAndIds(userId, distinctNotificationIds);
+    }
+
+    private Instant cutoff() {
+        return Instant.now().minus(INBOX_RETENTION);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #258 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- `GET /api/notifications`
  - 유저의 최근 알림 목록을 조회합니다.
  - 현재는 알림 페이지에서 최근 7일 간의 알림만 조회하도록 구현했습니다.
- `GET /api/notifications/unread-status`
  - 최근 알림 목록 중 읽지 않은 알림의 존재 여부를 조회합니다.
  - 읽지 않은 알림이 존재할 때 알림 아이콘에 배지를 표시하는 데 사용합니다.
- `PATCH /api/notifications/read-status`
  - 알림 목록의 알림을 읽음 처리합니다.

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
